### PR TITLE
Alternative of SLICE function to find sub array.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4320,8 +4320,8 @@
         1. Else the order of evaluation needs to be reversed to preserve left to right evaluation,
           1. Let _py_ be ? ToPrimitive(_y_, hint Number).
           1. Let _px_ be ? ToPrimitive(_x_, hint Number).
-        1. If both _px_ and _py_ are Strings, then
           1. If _py_ is a prefix of _px_, return *false*. (A String value _p_ is a prefix of String value _q_ if _q_ can be the string-concatenation of _p_ and some other String _r_. Note that any String is a prefix of itself, because _r_ may be the empty String.)
+        1. If Type(_px_) is String and Type(_py_) is String, then
           1. If _px_ is a prefix of _py_, return *true*.
           1. Let _k_ be the smallest nonnegative integer such that the code unit at index _k_ within _px_ is different from the code unit at index _k_ within _py_. (There must be such a _k_, for neither String is a prefix of the other.)
           1. Let _m_ be the integer that is the numeric value of the code unit at index _k_ within _px_.

--- a/spec.html
+++ b/spec.html
@@ -7444,7 +7444,7 @@
       <p>The abstract operation MakeConstructor requires a Function argument _F_ and optionally, a Boolean _writablePrototype_ and an object _prototype_. If _prototype_ is provided it is assumed to already contain, if needed, a `"constructor"` property whose value is _F_. This operation converts _F_ into a constructor by performing the following steps:</p>
       <emu-alg>
         1. Assert: _F_ is an ECMAScript function object.
-        1. Assert: _F_ has a [[Construct]] internal method.
+        1. Assert: IsConstructor(_F_) is *true*.
         1. Assert: _F_ is an extensible object that does not have a `prototype` own property.
         1. If _writablePrototype_ is not present, set _writablePrototype_ to *true*.
         1. If _prototype_ is not present, then
@@ -7765,7 +7765,7 @@
         <p>When the [[Construct]] internal method of a bound function exotic object, _F_ that was created using the bind function is called with a list of arguments _argumentsList_ and _newTarget_, the following steps are taken:</p>
         <emu-alg>
           1. Let _target_ be _F_.[[BoundTargetFunction]].
-          1. Assert: _target_ has a [[Construct]] internal method.
+          1. Assert: IsConstructor(_target_) is *true*.
           1. Let _boundArgs_ be _F_.[[BoundArguments]].
           1. Let _args_ be a new list containing the same values as the list _boundArgs_ in the same order followed by the same values as the list _argumentsList_ in the same order.
           1. If SameValue(_F_, _newTarget_) is *true*, set _newTarget_ to _target_.
@@ -7783,7 +7783,7 @@
           1. Let _obj_ be a newly created object.
           1. Set _obj_'s essential internal methods to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
           1. Set _obj_.[[Call]] as described in <emu-xref href="#sec-bound-function-exotic-objects-call-thisargument-argumentslist"></emu-xref>.
-          1. If _targetFunction_ has a [[Construct]] internal method, then
+          1. If IsConstructor(_targetFunction_) is *true*, then
             1. Set _obj_.[[Construct]] as described in <emu-xref href="#sec-bound-function-exotic-objects-construct-argumentslist-newtarget"></emu-xref>.
           1. Set _obj_.[[Prototype]] to _proto_.
           1. Set _obj_.[[Extensible]] to *true*.
@@ -9238,7 +9238,7 @@
         1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, `"construct"`).
         1. If _trap_ is *undefined*, then
-          1. Assert: _target_ has a [[Construct]] internal method.
+          1. Assert: IsConstructor(_target_) is *true*.
           1. Return ? Construct(_target_, _argumentsList_, _newTarget_).
         1. Let _argArray_ be CreateArrayFromList(_argumentsList_).
         1. Let _newObj_ be ? Call(_trap_, _handler_, &laquo; _target_, _argArray_, _newTarget_ &raquo;).
@@ -9271,7 +9271,7 @@
         1. Set _P_'s essential internal methods (except for [[Call]] and [[Construct]]) to the definitions specified in <emu-xref href="#sec-proxy-object-internal-methods-and-internal-slots"></emu-xref>.
         1. If IsCallable(_target_) is *true*, then
           1. Set _P_.[[Call]] as specified in <emu-xref href="#sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist"></emu-xref>.
-          1. If _target_ has a [[Construct]] internal method, then
+          1. If IsConstructor(_target_) is *true*, then
             1. Set _P_.[[Construct]] as specified in <emu-xref href="#sec-proxy-object-internal-methods-and-internal-slots-construct-argumentslist-newtarget"></emu-xref>.
         1. Set _P_.[[ProxyTarget]] to _target_.
         1. Set _P_.[[ProxyHandler]] to _handler_.

--- a/spec.html
+++ b/spec.html
@@ -4339,7 +4339,7 @@
           1. If _ny_ is *+&infin;*, return *true*.
           1. If _ny_ is *-&infin;*, return *false*.
           1. If _nx_ is *-&infin;*, return *true*.
-          1. If the mathematical value of _nx_ is less than the mathematical value of _ny_ &mdash;note that these mathematical values are both finite and not both zero&mdash;return *true*. Otherwise, return *false*.
+          1. If the mathematical value of _nx_ is less than the mathematical value of _ny_ &mdash; note that these mathematical values are both finite and not both zero &mdash; return *true*. Otherwise, return *false*.
       </emu-alg>
       <emu-note>
         <p>Step 3 differs from step 7 in the algorithm for the addition operator `+` (<emu-xref href="#sec-addition-operator-plus"></emu-xref>) in using &ldquo;and&rdquo; instead of &ldquo;or&rdquo;.</p>

--- a/spec.html
+++ b/spec.html
@@ -4328,7 +4328,8 @@
           1. Let _n_ be the integer that is the numeric value of the code unit at index _k_ within _py_.
           1. If _m_ &lt; _n_, return *true*. Otherwise, return *false*.
         1. Else,
-          1. Let _nx_ be ? ToNumber(_px_). Because _px_ and _py_ are primitive values evaluation order is not important.
+          1. NOTE: Because _px_ and _py_ are primitive values evaluation order is not important.
+          1. Let _nx_ be ? ToNumber(_px_).
           1. Let _ny_ be ? ToNumber(_py_).
           1. If _nx_ is *NaN*, return *undefined*.
           1. If _ny_ is *NaN*, return *undefined*.

--- a/spec.html
+++ b/spec.html
@@ -4320,8 +4320,8 @@
         1. Else the order of evaluation needs to be reversed to preserve left to right evaluation,
           1. Let _py_ be ? ToPrimitive(_y_, hint Number).
           1. Let _px_ be ? ToPrimitive(_x_, hint Number).
-          1. If _py_ is a prefix of _px_, return *false*. (A String value _p_ is a prefix of String value _q_ if _q_ can be the string-concatenation of _p_ and some other String _r_. Note that any String is a prefix of itself, because _r_ may be the empty String.)
         1. If Type(_px_) is String and Type(_py_) is String, then
+          1. If _py_ is a prefix of _px_, return *false*.
           1. If _px_ is a prefix of _py_, return *true*.
           1. Let _k_ be the smallest nonnegative integer such that the code unit at index _k_ within _px_ is different from the code unit at index _k_ within _py_. (There must be such a _k_, for neither String is a prefix of the other.)
           1. Let _m_ be the integer that is the numeric value of the code unit at index _k_ within _px_.
@@ -4342,6 +4342,9 @@
           1. If _nx_ is *-&infin;*, return *true*.
           1. If the mathematical value of _nx_ is less than the mathematical value of _ny_ &mdash; note that these mathematical values are both finite and not both zero &mdash; return *true*. Otherwise, return *false*.
       </emu-alg>
+      <emu-note>
+        <p>A String value _p_ is a prefix of String value _q_ if _q_ can be the string-concatenation of _p_ and some other String _r_. Note that any String is a prefix of itself, because _r_ may be the empty String.</p>
+      </emu-note>
       <emu-note>
         <p>Step 3 differs from step 7 in the algorithm for the addition operator `+` (<emu-xref href="#sec-addition-operator-plus"></emu-xref>) by using the logical-and operation instead of the logical-or operation.</p>
       </emu-note>

--- a/spec.html
+++ b/spec.html
@@ -33221,7 +33221,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Assert: Both Type(_x_) and Type(_y_) is Number.
           1. If _comparefn_ is not *undefined*, then
-            1. Let _v_ be ? Call(_comparefn_, *undefined*, &laquo; _x_, _y_ &raquo;).
+            1. Let _v_ be ? ToNumber(? Call(_comparefn_, *undefined*, &laquo; _x_, _y_ &raquo;)).
             1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
             1. If _v_ is *NaN*, return *+0*.
             1. Return _v_.

--- a/spec.html
+++ b/spec.html
@@ -4342,7 +4342,7 @@
           1. If the mathematical value of _nx_ is less than the mathematical value of _ny_ &mdash; note that these mathematical values are both finite and not both zero &mdash; return *true*. Otherwise, return *false*.
       </emu-alg>
       <emu-note>
-        <p>Step 3 differs from step 7 in the algorithm for the addition operator `+` (<emu-xref href="#sec-addition-operator-plus"></emu-xref>) in using &ldquo;and&rdquo; instead of &ldquo;or&rdquo;.</p>
+        <p>Step 3 differs from step 7 in the algorithm for the addition operator `+` (<emu-xref href="#sec-addition-operator-plus"></emu-xref>) by using the logical-and operation instead of the logical-or operation.</p>
       </emu-note>
       <emu-note>
         <p>The comparison of Strings uses a simple lexicographic ordering on sequences of code unit values. There is no attempt to use the more complex, semantically oriented definitions of character or string equality and collating order defined in the Unicode specification. Therefore String values that are canonically equal according to the Unicode standard could test as unequal. In effect this algorithm assumes that both Strings are already in normalized form. Also, note that for strings containing supplementary characters, lexicographic ordering on sequences of UTF-16 code unit values differs from that on sequences of code point values.</p>

--- a/spec.html
+++ b/spec.html
@@ -4253,6 +4253,17 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-isstringprefix" aoid="IsStringPrefix">
+      <h1>IsStringPrefix ( _p_, _q_ )</h1>
+      <p>The abstract operation IsStringPrefix determines if String _p_ is a prefix of String _q_.</p>
+      <emu-alg>
+        1. Assert: Type(_p_) is String.
+        1. Assert: Type(_q_) is String.
+        1. If _q_ can be the string-concatenation of _p_ and some other String _r_, return *true*. Otherwise, return *false*.
+        1. NOTE: Any String is a prefix of itself, because _r_ may be the empty String.
+      </emu-alg>
+    </emu-clause>
+
     <!-- es6num="7.2.9" -->
     <emu-clause id="sec-samevalue" aoid="SameValue">
       <h1>SameValue ( _x_, _y_ )</h1>
@@ -4321,8 +4332,8 @@
           1. Let _py_ be ? ToPrimitive(_y_, hint Number).
           1. Let _px_ be ? ToPrimitive(_x_, hint Number).
         1. If Type(_px_) is String and Type(_py_) is String, then
-          1. If _py_ is a prefix of _px_, return *false*.
-          1. If _px_ is a prefix of _py_, return *true*.
+          1. If IsStringPrefix(_py_, _px_), return *false*.
+          1. If IsStringPrefix(_px_, _py_), return *true*.
           1. Let _k_ be the smallest nonnegative integer such that the code unit at index _k_ within _px_ is different from the code unit at index _k_ within _py_. (There must be such a _k_, for neither String is a prefix of the other.)
           1. Let _m_ be the integer that is the numeric value of the code unit at index _k_ within _px_.
           1. Let _n_ be the integer that is the numeric value of the code unit at index _k_ within _py_.
@@ -4342,9 +4353,6 @@
           1. If _nx_ is *-&infin;*, return *true*.
           1. If the mathematical value of _nx_ is less than the mathematical value of _ny_&mdash;note that these mathematical values are both finite and not both zero&mdash;return *true*. Otherwise, return *false*.
       </emu-alg>
-      <emu-note>
-        <p>A String value _p_ is a prefix of String value _q_ if _q_ can be the string-concatenation of _p_ and some other String _r_. Note that any String is a prefix of itself, because _r_ may be the empty String.</p>
-      </emu-note>
       <emu-note>
         <p>Step 3 differs from step 7 in the algorithm for the addition operator `+` (<emu-xref href="#sec-addition-operator-plus"></emu-xref>) by using the logical-and operation instead of the logical-or operation.</p>
       </emu-note>

--- a/spec.html
+++ b/spec.html
@@ -4340,7 +4340,7 @@
           1. If _ny_ is *+&infin;*, return *true*.
           1. If _ny_ is *-&infin;*, return *false*.
           1. If _nx_ is *-&infin;*, return *true*.
-          1. If the mathematical value of _nx_ is less than the mathematical value of _ny_ &mdash; note that these mathematical values are both finite and not both zero &mdash; return *true*. Otherwise, return *false*.
+          1. If the mathematical value of _nx_ is less than the mathematical value of _ny_&mdash;note that these mathematical values are both finite and not both zero&mdash;return *true*. Otherwise, return *false*.
       </emu-alg>
       <emu-note>
         <p>A String value _p_ is a prefix of String value _q_ if _q_ can be the string-concatenation of _p_ and some other String _r_. Note that any String is a prefix of itself, because _r_ may be the empty String.</p>


### PR DESCRIPTION
// BACKEND CODE
function sliceFunc(origArray, a, b)
{
  if(a < 0)
  {
    a = origArray.length + a;
  }
  else if(a === undefined)
  {
    a = 0;
  }
  
  if((b<a && b > 0) || b == a)
  {
    return;
  }
  else if(b===undefined || b>origArray.length)
  {
    b=origArray.length;
  }
  else if(b < 0)
  {
    b = origArray.length + b;
    if(b === a || b < a)
    {
      return;
    }
  }
  
  var slicedArray=[];
  for(i=a;i<b;i++){
    slicedArray.push(origArray[i]);
  }
  return slicedArray;
}

// Proposal Detail...
On frontend we perform slicing on an array using below syntax:

  var numArr = [1, 2, 3, 4, 5];
  var subArr = numArr.slice(2, 4);

My proposed way of performing slicing

  var numArr = [1, 2, 3, 4, 5];
  var subArr = numArr[2...4];  // instead of defining the start and end index by using slice method we can directly define it inside the square bracket.
  
In my proposed code first number inside square bracket is starting index and second number is end index.
My proposal requires chnages in the Javascript engine to connect array square brackets with backend code to achieve my desired functionality which I could not so request you to review it and let me know your views on it.